### PR TITLE
ADD: Support for Ollama models with tooling

### DIFF
--- a/config/config_ollama.yml
+++ b/config/config_ollama.yml
@@ -1,0 +1,69 @@
+# Ollama provider example — runs the education scenario using a local model.
+#
+# User flow:
+#   1. Install Ollama: https://ollama.com
+#   2. ollama pull qwen2.5:7b
+#   3. python run.py --output_path results/ollama_education \
+#                    --config_path ./config/config_ollama.yml
+#
+# The model must support native tool-calling.
+# Verified: qwen2.5:7b, llama3.1:8b, mistral:7b-instruct
+# Models without tool support (e.g. tinyllama) will error at runtime.
+#
+# Running Ollama on a remote machine? Set HOST in config/llm_env.yml,
+# or add base_url to each llm block below.
+
+environment:
+  prompt_path: 'examples/education/input/wiki.md'
+  tools_file: ''
+  database_folder: ''
+  database_validators: ''
+
+# llm_intellagent overrides all framework LLMs (user sim, critique, policy extractor, etc.)
+llm_intellagent:
+  type: 'ollama'
+  name: 'qwen2.5:7b'
+
+# llm_chat overrides the chatbot being evaluated
+llm_chat:
+  type: 'ollama'
+  name: 'qwen2.5:7b'
+
+# Local models are slower than cloud APIs — increase timeouts and use 1 worker
+description_generator:
+  policies_config:
+    num_workers: 1
+    timeout: 120
+  edge_config:
+    num_workers: 1
+    timeout: 120
+  description_config:
+    num_workers: 1
+    timeout: 120
+  refinement_config:
+    num_workers: 1
+    timeout: 120
+
+event_generator:
+  symbolic_enrichment_config:
+    num_workers: 1
+    timeout: 120
+  symbolic_constraints_config:
+    num_workers: 1
+    timeout: 120
+  event_graph:
+    num_workers: 1
+    timeout: 300
+
+dialog_manager:
+  num_workers: 1
+  timeout: 3600
+  cost_limit: 999
+
+analysis:
+  num_workers: 1
+  timeout: 120
+
+dataset:
+  num_samples: 5
+  cost_limit: 999

--- a/config/llm_env.yml
+++ b/config/llm_env.yml
@@ -22,3 +22,6 @@ oracle:
   SERVICE_ENDPOINT: ''
   COMPARTMENT_ID: ''
 
+ollama:
+  HOST: 'http://localhost:11434'  # Change only if running Ollama on a remote machine
+

--- a/simulator/utils/llm_utils.py
+++ b/simulator/utils/llm_utils.py
@@ -303,5 +303,17 @@ def get_llm(config: dict, timeout=60):
             device=device,
             device_map=device_map
         )
+    elif config['type'].lower() == 'ollama':
+        from langchain_ollama import ChatOllama
+        # Ollama always starts a local HTTP server on port 11434 when installed.
+        # Override base_url here or set HOST in llm_env.yml only for remote Ollama servers.
+        return ChatOllama(
+            model=config['name'],
+            temperature=temperature,
+            base_url=config.get(
+                'base_url',
+                LLM_ENV.get('ollama', {}).get('HOST', 'http://localhost:11434'),
+            ),
+        )
     else:
         raise NotImplementedError("LLM not implemented")

--- a/tests/test_ollama_provider.py
+++ b/tests/test_ollama_provider.py
@@ -1,0 +1,66 @@
+import pytest
+
+FAKE_LLM_ENV = {
+    'openai': {'OPENAI_API_KEY': '', 'OPENAI_ORGANIZATION': '', 'OPENAI_API_BASE': ''},
+    'azure': {'AZURE_OPENAI_API_KEY': '', 'AZURE_OPENAI_ENDPOINT': '', 'OPENAI_API_VERSION': ''},
+    'google': {'GOOGLE_API_KEY': ''},
+    'anthropic_vertex': {'PROJECT_ID': '', 'REGION': ''},
+    'anthropic': {'ANTHROPIC_KEY': ''},
+    'oracle': {'SERVICE_ENDPOINT': '', 'COMPARTMENT_ID': ''},
+    'ollama': {'HOST': 'http://localhost:11434'},
+}
+
+@pytest.fixture(autouse=True)
+def patch_llm_env(monkeypatch):
+    import simulator.utils.llm_utils as lu
+    monkeypatch.setattr(lu, 'LLM_ENV', FAKE_LLM_ENV)
+
+
+def test_ollama_returns_chatollama():
+    from simulator.utils.llm_utils import get_llm
+    from langchain_ollama import ChatOllama
+
+    config = {'type': 'ollama', 'name': 'qwen2.5:7b'}
+    llm = get_llm(config)
+
+    assert isinstance(llm, ChatOllama)
+
+
+def test_ollama_uses_default_host():
+    from simulator.utils.llm_utils import get_llm
+    from langchain_ollama import ChatOllama
+
+    config = {'type': 'ollama', 'name': 'qwen2.5:7b'}
+    llm = get_llm(config)
+
+    assert isinstance(llm, ChatOllama)
+    assert llm.base_url == 'http://localhost:11434'
+
+
+def test_ollama_uses_config_base_url():
+    from simulator.utils.llm_utils import get_llm
+    from langchain_ollama import ChatOllama
+
+    config = {'type': 'ollama', 'name': 'llama3.1:8b', 'base_url': 'http://remote-machine:11434'}
+    llm = get_llm(config)
+
+    assert isinstance(llm, ChatOllama)
+    assert llm.base_url == 'http://remote-machine:11434'
+
+
+def test_ollama_case_insensitive():
+    from simulator.utils.llm_utils import get_llm
+    from langchain_ollama import ChatOllama
+
+    config = {'type': 'Ollama', 'name': 'mistral:7b-instruct'}
+    llm = get_llm(config)
+
+    assert isinstance(llm, ChatOllama)
+
+
+def test_llm_env_has_ollama_section():
+    import yaml
+    with open('config/llm_env.yml') as f:
+        env = yaml.safe_load(f)
+    assert 'ollama' in env
+    assert 'HOST' in env['ollama']


### PR DESCRIPTION
## Summary

  - Adds `ollama` as a supported LLM provider type in `get_llm()` via `langchain_ollama.ChatOllama`
  - Adds `ollama` section to `config/llm_env.yml` with a `HOST` override for remote Ollama servers
  - Adds `config/config_ollama.yml` reference config for running the education example with a local model
  - Adds `tests/test_ollama_provider.py` and root-level `conftest.py` to establish the project's test foundation