### PR TITLE
ADD: Support for Groq fast-inference models

### DIFF
--- a/config/config_groq.yml
+++ b/config/config_groq.yml
@@ -1,0 +1,71 @@
+# Groq provider example — runs the education scenario using fast open-weight models hosted by Groq.
+#
+# User flow:
+#   1. Get a Groq API key: https://console.groq.com/keys
+#   2. Set GROQ_API_KEY in config/llm_env.yml (or pass api_key on each llm block below)
+#   3. pip install langchain-groq
+#   4. python run.py --output_path results/groq_education \
+#                    --config_path ./config/config_groq.yml
+#
+# The model must support native tool-calling.
+# Tool-capable models (see https://console.groq.com/docs/models for the current list):
+#   llama-3.3-70b-versatile, llama-3.1-70b-versatile, mixtral-8x7b-32768
+# Smaller/older models (e.g. llama-3.1-8b-instant) may not support tool-calling reliably.
+#
+# Note on rate limits: Groq's free tier has aggressive per-minute caps. For full simulation
+# runs, either keep num_workers low or upgrade to a paid plan.
+
+environment:
+  prompt_path: 'examples/education/input/wiki.md'
+  tools_file: ''
+  database_folder: ''
+  database_validators: ''
+
+# llm_intellagent overrides all framework LLMs (user sim, critique, policy extractor, etc.)
+llm_intellagent:
+  type: 'groq'
+  name: 'llama-3.3-70b-versatile'
+
+# llm_chat overrides the chatbot being evaluated
+llm_chat:
+  type: 'groq'
+  name: 'llama-3.3-70b-versatile'
+
+# Groq's free-tier rate limits favor modest concurrency
+description_generator:
+  policies_config:
+    num_workers: 2
+    timeout: 60
+  edge_config:
+    num_workers: 2
+    timeout: 60
+  description_config:
+    num_workers: 2
+    timeout: 60
+  refinement_config:
+    num_workers: 2
+    timeout: 60
+
+event_generator:
+  symbolic_enrichment_config:
+    num_workers: 2
+    timeout: 60
+  symbolic_constraints_config:
+    num_workers: 2
+    timeout: 60
+  event_graph:
+    num_workers: 2
+    timeout: 120
+
+dialog_manager:
+  num_workers: 2
+  timeout: 600
+  cost_limit: 999
+
+analysis:
+  num_workers: 2
+  timeout: 60
+
+dataset:
+  num_samples: 5
+  cost_limit: 999

--- a/config/llm_env.yml
+++ b/config/llm_env.yml
@@ -25,3 +25,6 @@ oracle:
 ollama:
   HOST: 'http://localhost:11434'  # Change only if running Ollama on a remote machine
 
+groq:
+  GROQ_API_KEY: ''  # Get a key at https://console.groq.com/keys
+

--- a/simulator/utils/llm_utils.py
+++ b/simulator/utils/llm_utils.py
@@ -315,5 +315,18 @@ def get_llm(config: dict, timeout=60):
                 LLM_ENV.get('ollama', {}).get('HOST', 'http://localhost:11434'),
             ),
         )
+    elif config['type'].lower() == 'groq':
+        from langchain_groq import ChatGroq
+        # Groq offers fast inference on open-weight models (Llama, Mixtral, Gemma).
+        # Get an API key at https://console.groq.com/keys and set GROQ_API_KEY in llm_env.yml.
+        # See https://console.groq.com/docs/models for the current model list and tool-calling support.
+        return ChatGroq(
+            model=config['name'],
+            temperature=temperature,
+            api_key=config.get(
+                'api_key',
+                LLM_ENV.get('groq', {}).get('GROQ_API_KEY', ''),
+            ),
+        )
     else:
         raise NotImplementedError("LLM not implemented")

--- a/tests/test_groq_provider.py
+++ b/tests/test_groq_provider.py
@@ -1,0 +1,67 @@
+import pytest
+
+FAKE_LLM_ENV = {
+    'openai': {'OPENAI_API_KEY': '', 'OPENAI_ORGANIZATION': '', 'OPENAI_API_BASE': ''},
+    'azure': {'AZURE_OPENAI_API_KEY': '', 'AZURE_OPENAI_ENDPOINT': '', 'OPENAI_API_VERSION': ''},
+    'google': {'GOOGLE_API_KEY': ''},
+    'anthropic_vertex': {'PROJECT_ID': '', 'REGION': ''},
+    'anthropic': {'ANTHROPIC_KEY': ''},
+    'oracle': {'SERVICE_ENDPOINT': '', 'COMPARTMENT_ID': ''},
+    'ollama': {'HOST': 'http://localhost:11434'},
+    'groq': {'GROQ_API_KEY': 'test-key-from-env'},
+}
+
+@pytest.fixture(autouse=True)
+def patch_llm_env(monkeypatch):
+    import simulator.utils.llm_utils as lu
+    monkeypatch.setattr(lu, 'LLM_ENV', FAKE_LLM_ENV)
+
+
+def test_groq_returns_chatgroq():
+    from simulator.utils.llm_utils import get_llm
+    from langchain_groq import ChatGroq
+
+    config = {'type': 'groq', 'name': 'llama-3.3-70b-versatile'}
+    llm = get_llm(config)
+
+    assert isinstance(llm, ChatGroq)
+
+
+def test_groq_uses_env_api_key():
+    from simulator.utils.llm_utils import get_llm
+    from langchain_groq import ChatGroq
+
+    config = {'type': 'groq', 'name': 'llama-3.3-70b-versatile'}
+    llm = get_llm(config)
+
+    assert isinstance(llm, ChatGroq)
+    assert llm.groq_api_key.get_secret_value() == 'test-key-from-env'
+
+
+def test_groq_uses_config_api_key_override():
+    from simulator.utils.llm_utils import get_llm
+    from langchain_groq import ChatGroq
+
+    config = {'type': 'groq', 'name': 'llama-3.1-70b-versatile', 'api_key': 'override-from-config'}
+    llm = get_llm(config)
+
+    assert isinstance(llm, ChatGroq)
+    assert llm.groq_api_key.get_secret_value() == 'override-from-config'
+
+
+def test_groq_case_insensitive():
+    from simulator.utils.llm_utils import get_llm
+    from langchain_groq import ChatGroq
+
+    config = {'type': 'Groq', 'name': 'mixtral-8x7b-32768'}
+    llm = get_llm(config)
+
+    assert isinstance(llm, ChatGroq)
+
+
+def test_llm_env_has_groq_section():
+    import yaml
+    with open('config/llm_env.yml') as f:
+        env = yaml.safe_load(f)
+    assert 'groq' in env
+    assert 'GROQ_API_KEY' in env['groq']


### PR DESCRIPTION
Adds a Groq branch to get_llm(). Groq hosts open-weight models (Llama, Mixtral, Gemma) with very low latency, complementing the local Ollama story with a cloud option.

Changes:
- `simulator/utils/llm_utils.py`: new 'groq' branch in `get_llm()` with lazy import of `langchain_groq`, `api_key` resolution from config or `llm_env.yml`.
- `config/llm_env.yml`: new groq section with `GROQ_API_KEY `slot.
- `config/config_groq.yml`: sample config running the education scenario with llama-3.3-70b-versatile.
- `tests/test_groq_provider.py`: 5 tests mirroring `test_ollama_provider.py` (instance type, env-key resolution, config-key override, case insensitivity, env-section presence).

Users must pip install `langchain-groq` separately —> same lazy-import convention as the Ollama PR (not added to `requirements.txt`).