### PR TITLE
CHORE: Add unit tests for agent graphs module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "intellagent"
+version = "0.1.0"
+description = "IntellAgent simulator and evaluation framework"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+  "google-cloud-aiplatform==1.75.0",
+  "anthropic[vertex]==0.42.0",
+  "langchain_google_vertexai==2.0.9",
+  "langchain==0.3.7",
+  "langchain_core==0.3.15",
+  "langchain_openai==0.2.5",
+  "langgraph==0.2.44",
+  "pandas==2.2.3",
+  "langchain_community==0.3.5",
+  "langchain_ollama==0.2.0",
+  "networkx==3.2.1",
+  "streamlit==1.39.0",
+  "plotly==5.24.1",
+  "langchain_google_genai==2.0.7",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest==9.1.1",
+]
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+include = ["simulator*"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,9 @@ langchain_openai==0.2.5
 langgraph==0.2.44
 pandas==2.2.3
 langchain_community==0.3.5
+langchain_ollama==0.2.0
 networkx==3.2.1
 streamlit==1.39.0
 plotly==5.24.1
 langchain_google_genai==2.0.7
+pytest==9.1.1

--- a/tests/agents_graphs/test_dialog_graph.py
+++ b/tests/agents_graphs/test_dialog_graph.py
@@ -1,0 +1,139 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.graph import END
+
+from simulator.agents_graphs.dialog_graph import Dialog, set_user_message
+
+
+def make_dialog(user_response, chatbot_response, critique_response, memory=None, intermediate_processing=None):
+    user = Mock()
+    user.invoke.return_value = user_response
+    chatbot = Mock()
+    chatbot.invoke.return_value = chatbot_response
+    critique = Mock()
+    critique.invoke.return_value = critique_response
+    return Dialog(
+        user=user,
+        chatbot=chatbot,
+        critique=critique,
+        intermediate_processing=intermediate_processing or (lambda state: END),
+        memory=memory,
+    )
+
+
+def test_user_end_condition_routes_to_critique_on_stop_signal():
+    dialog = make_dialog({}, {}, {})
+    assert dialog.user_end_condition({"stop_signal": "###STOP"}) == "end_critique"
+    assert dialog.user_end_condition({"stop_signal": ""}) == "chatbot"
+
+
+def test_critique_end_condition_uses_intermediate_processing():
+    dialog = make_dialog({}, {}, {}, intermediate_processing=lambda state: "END")
+    assert dialog.critique_end_condition({"stop_signal": "###STOP"}) == END
+
+    dialog = make_dialog({}, {}, {}, intermediate_processing=lambda state: "user")
+    assert dialog.critique_end_condition({"stop_signal": "###STOP"}) == "user"
+
+
+def test_set_user_message_without_feedback():
+    messages = set_user_message(
+        {
+            "chatbot_messages": [HumanMessage(content="hello"), AIMessage(content="world")],
+            "critique_feedback": "",
+            "user_thoughts": [],
+            "stop_signal": "",
+        }
+    )
+
+    assert len(messages) == 1
+    assert messages[0].type == "human"
+    assert "Conversation" in messages[0].content
+
+
+def test_set_user_message_with_feedback_adds_retry_prompt():
+    messages = set_user_message(
+        {
+            "chatbot_messages": [HumanMessage(content="hello"), AIMessage(content="world")],
+            "critique_feedback": "Please stop earlier",
+            "user_thoughts": ["Thought: because"],
+            "stop_signal": "###STOP",
+        }
+    )
+
+    assert len(messages) == 3
+    assert messages[1].type == "ai"
+    assert "User Response" in messages[1].content
+    assert messages[2].type == "human"
+    assert "Please stop earlier" in messages[2].content
+
+
+def test_simulated_user_node_records_stop_signal_and_thoughts():
+    memory = SimpleNamespace(thoughts=[], dialog=[], tools=[])
+    memory.insert_thought = Mock(side_effect=lambda thread_id, thought: memory.thoughts.append((thread_id, thought)))
+    memory.insert_dialog = Mock(side_effect=lambda thread_id, role, content: memory.dialog.append((thread_id, role, content)))
+    memory.insert_tool = Mock(side_effect=lambda thread_id, name, args, output: memory.tools.append((thread_id, name, args, output)))
+
+    dialog = make_dialog(
+        user_response={"response": "###STOP", "thought": "I should stop"},
+        chatbot_response={},
+        critique_response={},
+        memory=memory,
+    )
+
+    result = dialog.simulated_user_node(
+        {
+            "user_messages": [HumanMessage(content="start")],
+            "chatbot_messages": [HumanMessage(content="hello")],
+            "user_thoughts": [],
+            "thread_id": "thread-1",
+            "critique_feedback": "",
+            "stop_signal": "",
+        }
+    )
+
+    assert result["stop_signal"] == "###STOP"
+    assert result["user_thoughts"] == ["I should stop"]
+    assert memory.thoughts == [("thread-1", "I should stop")]
+    assert memory.dialog == [("thread-1", "Human", "###STOP")]
+
+
+def test_chat_bot_node_returns_last_ai_message_and_records_messages():
+    chatbot_response = {
+        "messages": [
+            HumanMessage(content="start"),
+            AIMessage(content="tool output"),
+            AIMessage(content="final answer"),
+        ]
+    }
+    dialog = make_dialog(user_response={}, chatbot_response=chatbot_response, critique_response={})
+
+    result = dialog.chat_bot_node(
+        {
+            "chatbot_messages": [HumanMessage(content="start")],
+            "chatbot_args": {"x": 1},
+            "thread_id": "thread-1",
+        }
+    )
+
+    assert len(result["chatbot_messages"]) == 2
+    assert result["chatbot_messages"][-1].content == "final answer"
+    assert result["user_messages"][0].content == "final answer"
+
+
+def test_critique_node_uses_last_user_thought():
+    critique = Mock()
+    critique.invoke.return_value = SimpleNamespace(content="CORRECT")
+    dialog = make_dialog(user_response={}, chatbot_response={}, critique_response={}, intermediate_processing=lambda state: END)
+    dialog.critique = critique
+
+    result = dialog.critique_node(
+        {
+            "user_thoughts": ["Thought: they followed the policy"],
+            "chatbot_messages": [HumanMessage(content="hi"), AIMessage(content="done")],
+        }
+    )
+
+    assert result == {"critique_feedback": "CORRECT"}
+    assert "they followed the policy" in critique.invoke.call_args.args[0]["reason"]

--- a/tests/agents_graphs/test_event_graph.py
+++ b/tests/agents_graphs/test_event_graph.py
@@ -1,0 +1,95 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pandas as pd
+
+from simulator.agents_graphs.event_graph import EventGraph
+
+
+def make_graph(executors=None, restriction_llm=None, final_llm=None):
+    executors = executors or {}
+    if restriction_llm is None:
+        restriction_llm = Mock()
+        restriction_llm.invoke.return_value = SimpleNamespace(content="row must be filtered")
+    if final_llm is None:
+        final_llm = Mock()
+        final_llm.invoke.return_value = final_llm
+        final_llm.dict.return_value = {"scenario": "final scenario"}
+    return EventGraph(executors=executors, llm_filter_constraints=restriction_llm, llm_final_response=final_llm)
+
+
+def test_get_end_condition_routes_to_executor_until_rows_empty():
+    condition = make_graph().get_end_condition()
+
+    assert condition({"rows_to_generate": [{"table_name": "users", "row": "{}"}]}) == "executor"
+    assert condition({"rows_to_generate": []}) == "final_response_node"
+
+
+def test_restriction_node_builds_cur_restrictions():
+    restriction_llm = Mock()
+    restriction_llm.invoke.return_value = SimpleNamespace(content="filter this row")
+    graph = make_graph(restriction_llm=restriction_llm)
+    node = graph.get_restriction_node()
+
+    result = node(
+        {
+            "rows_to_generate": [{"table_name": "users", "row": "name: alice"}],
+            "all_restrictions": "max 1 row",
+            "variables_definitions": "value: 1\n",
+        }
+    )
+
+    assert result == {"cur_restrictions": "filter this row"}
+    called = restriction_llm.invoke.call_args.args[0]
+    assert called["row"] == "name: alice"
+    assert "max 1 row" in called["restrictions"]
+
+
+def test_executor_node_updates_dataset_and_variables():
+    executor = Mock()
+    executor.system_prompt = SimpleNamespace(format_messages=Mock(return_value=[SimpleNamespace(content="system")]))
+    executor.invoke.return_value = {
+        "messages": [SimpleNamespace(content="start"), SimpleNamespace(content="```yml\nvalue: 7\n```")],
+        "args": {"dataset": {"users": pd.DataFrame([{"id": 1}])}},
+    }
+    graph = make_graph(executors={"users": executor})
+    node = graph.get_executor_node()
+    dataset = {"users": pd.DataFrame([{"id": 1}])}
+    state = {
+        "rows_to_generate": [{"table_name": "users", "row": "id: 2"}],
+        "rows_generated": [],
+        "cur_restrictions": None,
+        "all_restrictions": "row must exist",
+        "variables_definitions": "",
+        "dataset": dataset,
+    }
+
+    result = node(state)
+
+    assert result["rows_to_generate"] == []
+    assert result["rows_generated"] == [{"table_name": "users", "row": "id: 2"}]
+    assert "value: 7" in result["variables_definitions"]
+    assert list(result["dataset"]["users"].columns) == ["id"]
+    called = executor.invoke.call_args.args[0]
+    assert called["args"]["dataset"] is dataset
+
+
+def test_final_node_formats_rows_and_response():
+    final_llm = Mock()
+    final_llm.invoke.return_value = final_llm
+    final_llm.dict.return_value = {"scenario": "normalized scenario"}
+    graph = make_graph(final_llm=final_llm)
+    node = graph.get_final_node()
+    dataset = {"users": pd.DataFrame([{"id": 1, "name": "alice"}])}
+
+    result = node(
+        {
+            "dataset": dataset,
+            "variables_definitions": "value: 1\n",
+            "event_description": "a user update",
+        }
+    )
+
+    assert result["final_response_scenario"] == "normalized scenario"
+    assert "## Table: users" in result["final_response_table_rows"]
+    assert final_llm.invoke.call_args.args[0]["scenario"] == "a user update"

--- a/tests/agents_graphs/test_langgraph_tool.py
+++ b/tests/agents_graphs/test_langgraph_tool.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langgraph.graph import END
+
+from simulator.agents_graphs.langgraph_tool import AgentTools, ToolNode, should_continue
+
+
+def test_should_continue_routes_to_tools_when_tool_calls_exist():
+    assert should_continue(
+        {
+            "messages": [
+                AIMessage(content="use tool", tool_calls=[{"name": "x", "args": {}, "id": "1"}])
+            ]
+        }
+    ) == "tools"
+
+
+def test_should_continue_routes_to_end_when_no_tool_calls():
+    assert should_continue({"messages": [AIMessage(content="final answer")]}) == END
+
+
+def test_tool_node_merges_state_args_and_returns_tool_message():
+    def lookup(query, session):
+        return f"{query}:{session}"
+
+    node = ToolNode([SimpleNamespace(name="lookup", func=lookup)])
+    state = {
+        "messages": [
+            HumanMessage(content="start"),
+            AIMessage(
+                content="call tool",
+                tool_calls=[{"name": "lookup", "args": {"query": "abc"}, "id": "1"}],
+            ),
+        ],
+        "args": {"session": "s1"},
+    }
+
+    result = node._func(state)
+
+    assert result["args"] == {"session": "s1"}
+    assert len(result["messages"]) == 1
+    assert isinstance(result["messages"][0], ToolMessage)
+    assert result["messages"][0].content == "abc:s1"
+    assert result["messages"][0].tool_call_id == "1"
+
+
+def test_agent_tools_get_call_model_wraps_llm_response():
+    llm = Mock()
+    llm.invoke.return_value = AIMessage(content="hello there")
+    agent = AgentTools(llm=llm, tools=[])
+
+    result = agent.get_call_model()({"messages": [HumanMessage(content="hi")], "args": {}})
+
+    assert len(result["messages"]) == 1
+    assert result["messages"][0].content == "hello there"
+    assert result["messages"][0].type == "ai"
+    llm.invoke.assert_called_once()
+    assert len(llm.invoke.call_args.args) == 1
+    assert llm.invoke.call_args.args[0][0].content == "hi"
+    assert llm.invoke.call_args.args[0][0].type == "human"
+
+
+def test_agent_tools_init_with_no_tools_builds_graph():
+    llm = Mock()
+    llm.invoke.return_value = AIMessage(content="final")
+    agent = AgentTools(llm=llm, tools=[])
+
+    assert agent.tools == []
+    assert agent.graph is not None

--- a/tests/agents_graphs/test_plan_and_execute.py
+++ b/tests/agents_graphs/test_plan_and_execute.py
@@ -1,0 +1,108 @@
+from unittest.mock import Mock
+
+from langgraph.graph import END
+
+from simulator.agents_graphs.plan_and_execute import Plan, PlanExecuteImplementation, SingleStep, should_end
+
+
+def make_impl(planner_output, replanner_output, executor=None):
+    planner = Mock()
+    planner.invoke.return_value = planner_output
+    replanner = Mock()
+    replanner.invoke.return_value = replanner_output
+    return PlanExecuteImplementation(planner=planner, executor=executor or {}, replanner=replanner), planner, replanner
+
+
+def test_should_end_returns_end_for_empty_plan():
+    assert should_end({"plan": []}) == END
+
+
+def test_should_end_returns_agent_for_non_empty_plan():
+    assert should_end({"plan": [{"content": "do something"}]}) == "agent"
+
+
+def test_get_planner_function_maps_plan_shape():
+    planner_output = Plan(
+        steps=[SingleStep(content="step 1", executor="search")],
+        final_response="done",
+    )
+    impl, planner, _ = make_impl(planner_output, planner_output)
+
+    result = impl.get_planner_function()({"input": "build a plan"})
+
+    assert result == {
+        "plan": planner_output.dict()["steps"],
+        "response": "done",
+    }
+    planner.invoke.assert_called_once_with("build a plan")
+
+
+def test_get_replanner_function_maps_plan_shape():
+    replanner_output = Plan(
+        steps=[SingleStep(content="step 2", executor="Response")],
+        final_response="final answer",
+    )
+    impl, _, replanner = make_impl(replanner_output, replanner_output)
+
+    state = {"input": "prompt", "plan": [], "past_steps": [], "response": "", "args": {}}
+    result = impl.get_replanner_function()(state)
+
+    assert result == {
+        "plan": replanner_output.dict()["steps"],
+        "response": "final answer",
+    }
+    replanner.invoke.assert_called_once_with(state)
+
+
+def test_executor_short_circuits_for_response_step():
+    planner_output = Plan(steps=[SingleStep(content="step 1", executor="Response")], final_response="done")
+    impl, _, _ = make_impl(planner_output, planner_output)
+
+    result = impl.get_executor_function()(
+        {"plan": [{"content": "answer the user", "executor": "Response"}], "args": {"x": 1}}
+    )
+
+    assert result == {"past_steps": [("answer the user", "answer the user")]}
+
+
+def test_executor_dispatches_to_named_executor():
+    named_executor = Mock()
+    named_executor.invoke.return_value = {
+        "messages": [Mock(content="intermediate"), Mock(content="final tool result")],
+        "args": {"updated": True},
+    }
+    planner_output = Plan(steps=[SingleStep(content="step 1", executor="search")], final_response="done")
+    impl, _, _ = make_impl(planner_output, planner_output, executor={"search": named_executor})
+
+    result = impl.get_executor_function()(
+        {"plan": [{"content": "look up account", "executor": "search"}], "args": {"session": "abc"}}
+    )
+
+    assert result == {
+        "past_steps": [("look up account", "final tool result")],
+        "args": {"updated": True},
+    }
+    assert "look up account" in named_executor.invoke.call_args.args[0]
+    assert named_executor.invoke.call_args.kwargs == {"additional_args": {"session": "abc"}}
+
+
+def test_graph_smoke_path():
+    planner_output = Plan(
+        steps=[SingleStep(content="look up account", executor="search")],
+        final_response="done",
+    )
+    replanner_output = Plan(steps=[], final_response="all set")
+    named_executor = Mock()
+    named_executor.invoke.return_value = {
+        "messages": [Mock(content="intermediate"), Mock(content="tool result")],
+        "args": {"updated": True},
+    }
+    impl, _, _ = make_impl(planner_output, replanner_output, executor={"search": named_executor})
+
+    result = impl.graph.invoke(
+        {"input": "summarize the plan", "plan": [], "past_steps": [], "response": "", "args": {}}
+    )
+
+    assert result["response"] == "all set"
+    assert result["past_steps"] == [("look up account", "tool result")]
+    assert named_executor.invoke.call_args.kwargs == {"additional_args": {}}


### PR DESCRIPTION
Added unit tests to the agent graph module.

To verify run: `uv run pytest`

In this PR I updated the requiremnts.txt to reflect the addition of pytest. 

Added packaging and test configuration to make the repository installable and the test suite runnable in a standard Python environment.
 
pyproject.toml defines the project metadata, dependencies, dev extras, and package discovery so `uv pip install -e ".[dev]"` works and simulator imports resolve reliably.
 
pytest.ini sets testpaths = tests so pytest discovers the suite consistently from the repo root without requiring path hacks or a conftest.py.

This makes local development and CI setup reproducible across machines

**Note** This PR did utilize the help of AI to write and generate code, but it was reviewed and tested.

@Eladlev please take chance whenever you can, and let me know if there are any additional tests that may have been missed.

Primary focus was on the `agent_graph` module for ease of PR review, we can gradually introduce the other testing modules.