### PR TITLE
Unit tests for utils folder

### DIFF
--- a/tests/agents_graphs/test_dialog_graph.py
+++ b/tests/agents_graphs/test_dialog_graph.py
@@ -24,12 +24,14 @@ def make_dialog(user_response, chatbot_response, critique_response, memory=None,
 
 
 def test_user_end_condition_routes_to_critique_on_stop_signal():
+    """When the user stop signal is present, then the dialog routes to critique instead of the chatbot."""
     dialog = make_dialog({}, {}, {})
     assert dialog.user_end_condition({"stop_signal": "###STOP"}) == "end_critique"
     assert dialog.user_end_condition({"stop_signal": ""}) == "chatbot"
 
 
 def test_critique_end_condition_uses_intermediate_processing():
+    """When intermediate processing ends the dialog, then critique routes to END; otherwise it loops back to user."""
     dialog = make_dialog({}, {}, {}, intermediate_processing=lambda state: "END")
     assert dialog.critique_end_condition({"stop_signal": "###STOP"}) == END
 
@@ -38,6 +40,7 @@ def test_critique_end_condition_uses_intermediate_processing():
 
 
 def test_set_user_message_without_feedback():
+    """When there is no critique feedback, then the user prompt contains only the conversation summary."""
     messages = set_user_message(
         {
             "chatbot_messages": [HumanMessage(content="hello"), AIMessage(content="world")],
@@ -53,6 +56,7 @@ def test_set_user_message_without_feedback():
 
 
 def test_set_user_message_with_feedback_adds_retry_prompt():
+    """When critique feedback exists, then the retry prompt includes the prior response and feedback."""
     messages = set_user_message(
         {
             "chatbot_messages": [HumanMessage(content="hello"), AIMessage(content="world")],
@@ -70,6 +74,7 @@ def test_set_user_message_with_feedback_adds_retry_prompt():
 
 
 def test_simulated_user_node_records_stop_signal_and_thoughts():
+    """When the user model returns a stop signal, then the node stores thoughts and stop state in memory."""
     memory = SimpleNamespace(thoughts=[], dialog=[], tools=[])
     memory.insert_thought = Mock(side_effect=lambda thread_id, thought: memory.thoughts.append((thread_id, thought)))
     memory.insert_dialog = Mock(side_effect=lambda thread_id, role, content: memory.dialog.append((thread_id, role, content)))
@@ -100,6 +105,7 @@ def test_simulated_user_node_records_stop_signal_and_thoughts():
 
 
 def test_chat_bot_node_returns_last_ai_message_and_records_messages():
+    """When the chatbot emits tool and final messages, then the node returns the post-human slice and final answer."""
     chatbot_response = {
         "messages": [
             HumanMessage(content="start"),
@@ -123,6 +129,7 @@ def test_chat_bot_node_returns_last_ai_message_and_records_messages():
 
 
 def test_critique_node_uses_last_user_thought():
+    """When critique runs, then the last user thought is passed into the critique reasoning payload."""
     critique = Mock()
     critique.invoke.return_value = SimpleNamespace(content="CORRECT")
     dialog = make_dialog(user_response={}, chatbot_response={}, critique_response={}, intermediate_processing=lambda state: END)

--- a/tests/agents_graphs/test_event_graph.py
+++ b/tests/agents_graphs/test_event_graph.py
@@ -19,6 +19,7 @@ def make_graph(executors=None, restriction_llm=None, final_llm=None):
 
 
 def test_get_end_condition_routes_to_executor_until_rows_empty():
+    """When rows remain to generate, then the event graph routes to the executor; otherwise it finalizes."""
     condition = make_graph().get_end_condition()
 
     assert condition({"rows_to_generate": [{"table_name": "users", "row": "{}"}]}) == "executor"
@@ -26,6 +27,7 @@ def test_get_end_condition_routes_to_executor_until_rows_empty():
 
 
 def test_restriction_node_builds_cur_restrictions():
+    """When the restriction node runs, then it computes row-level constraints from the current state."""
     restriction_llm = Mock()
     restriction_llm.invoke.return_value = SimpleNamespace(content="filter this row")
     graph = make_graph(restriction_llm=restriction_llm)
@@ -46,6 +48,7 @@ def test_restriction_node_builds_cur_restrictions():
 
 
 def test_executor_node_updates_dataset_and_variables():
+    """When the executor processes a row, then it updates the dataset, generated rows, and variable definitions."""
     executor = Mock()
     executor.system_prompt = SimpleNamespace(format_messages=Mock(return_value=[SimpleNamespace(content="system")]))
     executor.invoke.return_value = {
@@ -75,6 +78,7 @@ def test_executor_node_updates_dataset_and_variables():
 
 
 def test_final_node_formats_rows_and_response():
+    """When the final node runs, then it formats dataset rows and returns the normalized scenario."""
     final_llm = Mock()
     final_llm.invoke.return_value = final_llm
     final_llm.dict.return_value = {"scenario": "normalized scenario"}

--- a/tests/agents_graphs/test_langgraph_tool.py
+++ b/tests/agents_graphs/test_langgraph_tool.py
@@ -8,6 +8,7 @@ from simulator.agents_graphs.langgraph_tool import AgentTools, ToolNode, should_
 
 
 def test_should_continue_routes_to_tools_when_tool_calls_exist():
+    """When the last AI message contains tool calls, then the graph routes to the tools node."""
     assert should_continue(
         {
             "messages": [
@@ -18,10 +19,12 @@ def test_should_continue_routes_to_tools_when_tool_calls_exist():
 
 
 def test_should_continue_routes_to_end_when_no_tool_calls():
+    """When the last AI message has no tool calls, then the graph terminates."""
     assert should_continue({"messages": [AIMessage(content="final answer")]}) == END
 
 
 def test_tool_node_merges_state_args_and_returns_tool_message():
+    """When tool execution needs shared args, then the tool node merges them and returns tool messages."""
     def lookup(query, session):
         return f"{query}:{session}"
 
@@ -47,6 +50,7 @@ def test_tool_node_merges_state_args_and_returns_tool_message():
 
 
 def test_agent_tools_get_call_model_wraps_llm_response():
+    """When the call model runs, then it passes messages to the LLM and wraps the response in graph state."""
     llm = Mock()
     llm.invoke.return_value = AIMessage(content="hello there")
     agent = AgentTools(llm=llm, tools=[])
@@ -63,6 +67,7 @@ def test_agent_tools_get_call_model_wraps_llm_response():
 
 
 def test_agent_tools_init_with_no_tools_builds_graph():
+    """When an agent is created without tools, then it still builds a runnable graph around the LLM."""
     llm = Mock()
     llm.invoke.return_value = AIMessage(content="final")
     agent = AgentTools(llm=llm, tools=[])

--- a/tests/agents_graphs/test_plan_and_execute.py
+++ b/tests/agents_graphs/test_plan_and_execute.py
@@ -14,14 +14,17 @@ def make_impl(planner_output, replanner_output, executor=None):
 
 
 def test_should_end_returns_end_for_empty_plan():
+    """When the plan is empty, then the workflow terminates."""
     assert should_end({"plan": []}) == END
 
 
 def test_should_end_returns_agent_for_non_empty_plan():
+    """When plan steps remain, then the workflow routes back to the agent node."""
     assert should_end({"plan": [{"content": "do something"}]}) == "agent"
 
 
 def test_get_planner_function_maps_plan_shape():
+    """When the planner runs, then its structured output is mapped into graph state."""
     planner_output = Plan(
         steps=[SingleStep(content="step 1", executor="search")],
         final_response="done",
@@ -38,6 +41,7 @@ def test_get_planner_function_maps_plan_shape():
 
 
 def test_get_replanner_function_maps_plan_shape():
+    """When replanning runs, then the returned plan and final response are preserved in graph state."""
     replanner_output = Plan(
         steps=[SingleStep(content="step 2", executor="Response")],
         final_response="final answer",
@@ -55,6 +59,7 @@ def test_get_replanner_function_maps_plan_shape():
 
 
 def test_executor_short_circuits_for_response_step():
+    """When the next step is a direct response, then the executor short-circuits without calling tools."""
     planner_output = Plan(steps=[SingleStep(content="step 1", executor="Response")], final_response="done")
     impl, _, _ = make_impl(planner_output, planner_output)
 
@@ -66,6 +71,7 @@ def test_executor_short_circuits_for_response_step():
 
 
 def test_executor_dispatches_to_named_executor():
+    """When the next step targets a named executor, then the implementation invokes that executor with args."""
     named_executor = Mock()
     named_executor.invoke.return_value = {
         "messages": [Mock(content="intermediate"), Mock(content="final tool result")],
@@ -87,6 +93,7 @@ def test_executor_dispatches_to_named_executor():
 
 
 def test_graph_smoke_path():
+    """When the plan-execute graph runs end to end, then it executes the step and replans to completion."""
     planner_output = Plan(
         steps=[SingleStep(content="look up account", executor="search")],
         final_response="done",

--- a/tests/utils/unit/test_file_reading.py
+++ b/tests/utils/unit/test_file_reading.py
@@ -1,0 +1,259 @@
+import os
+from textwrap import dedent
+
+import yaml
+
+from simulator.utils.file_reading import (
+    get_last_created_directory,
+    get_last_db,
+    get_latest_dataset,
+    get_latest_file,
+    get_validators_from_module,
+    override_config,
+    override_llm,
+    update_dict_keys_if_exists,
+    validator,
+)
+
+
+def test_get_latest_file_returns_newest_matching_file(tmp_path):
+    """When a directory has multiple matching files, then the newest matching file name is returned."""
+    old_file = tmp_path / "older.pickle"
+    new_file = tmp_path / "newer.pickle"
+    old_file.write_text("old")
+    new_file.write_text("new")
+    os.utime(old_file, (1, 1))
+    os.utime(new_file, (2, 2))
+
+    result = get_latest_file(tmp_path)
+
+    assert result == "newer.pickle"
+
+
+def test_get_latest_file_returns_none_when_no_matching_files_exist(tmp_path):
+    """When no files match the requested extension, then the helper returns None instead of raising."""
+    (tmp_path / "notes.txt").write_text("irrelevant")
+
+    result = get_latest_file(tmp_path, extension="pickle")
+
+    assert result is None
+
+
+def test_get_latest_file_honors_custom_extension(tmp_path):
+    """When a custom extension is requested, then only matching files are considered for the latest result."""
+    old_file = tmp_path / "older.csv"
+    new_file = tmp_path / "newer.csv"
+    ignored_file = tmp_path / "ignored.pickle"
+    old_file.write_text("old")
+    new_file.write_text("new")
+    ignored_file.write_text("ignore")
+    os.utime(old_file, (1, 1))
+    os.utime(new_file, (2, 2))
+
+    result = get_latest_file(tmp_path, extension="csv")
+
+    assert result == "newer.csv"
+
+
+def test_validator_decorator_marks_function_with_collection_metadata():
+    """When a validator is decorated, then it carries the table and collection markers used by discovery."""
+
+    @validator(table="users")
+    def validate_users(df, dataset):
+        return df, dataset
+
+    assert validate_users.is_collected is True
+    assert validate_users.table == "users"
+
+
+def test_get_validators_from_module_returns_only_matching_validators(tmp_path):
+    """When a module exports multiple validators, then only the ones for the requested table are collected."""
+    module_path = tmp_path / "validators.py"
+    module_path.write_text(
+        dedent(
+            """
+            from simulator.utils.file_reading import validator
+
+            @validator(table="users")
+            def users_validator(df, dataset):
+                return df, dataset
+
+            @validator(table="orders")
+            def orders_validator(df, dataset):
+                return df, dataset
+
+            def plain_function(df, dataset):
+                return df, dataset
+            """
+        )
+    )
+
+    validators = get_validators_from_module(str(module_path), "users")
+
+    assert len(validators) == 1
+    assert validators[0].__name__ == "users_validator"
+
+
+def test_get_validators_from_module_returns_empty_list_for_missing_module(tmp_path):
+    """When the validator module path does not exist, then discovery should fail closed with an empty list."""
+    missing_module = tmp_path / "missing_validators.py"
+
+    validators = get_validators_from_module(str(missing_module), "users")
+
+    assert validators == []
+
+
+def test_update_dict_keys_if_exists_only_updates_preexisting_keys():
+    """When overriding a dictionary, then only keys already present in the target are updated."""
+    target = {"keep": 1, "change": 2}
+    source = {"change": 20, "new": 30}
+
+    update_dict_keys_if_exists(target, source)
+
+    assert target == {"keep": 1, "change": 20}
+
+
+def test_override_llm_updates_all_supported_nested_sections():
+    """When an llm override is applied, then every supported nested config section receives updated existing keys only."""
+    config = {
+        "environment": {"task_description": {"llm": {"type": "openai", "name": "base"}}},
+        "description_generator": {
+            "llm_policy": {"type": "openai", "name": "base", "temperature": 0.0},
+            "llm_edge": {"type": "openai", "name": "base", "temperature": 0.0},
+            "llm_description": {"type": "openai", "name": "base", "temperature": 0.0},
+            "llm_refinement": {"type": "openai", "name": "base", "temperature": 0.0},
+        },
+        "event_generator": {"event_graph": {"llm": {"type": "openai", "name": "base", "temperature": 0.0}}},
+        "dialog_manager": {
+            "critique_config": {"llm": {"type": "openai", "name": "base", "temperature": 0.0}},
+            "llm_user": {"type": "openai", "name": "base", "temperature": 0.0},
+        },
+        "analysis": {"llm": {"type": "openai", "name": "base", "temperature": 0.0}},
+    }
+    llm_override = {"type": "azure", "name": "new-model", "temperature": 0.25}
+
+    result = override_llm(config, llm_override)
+
+    assert result["environment"]["task_description"]["llm"]["type"] == "azure"
+    assert result["description_generator"]["llm_policy"]["name"] == "new-model"
+    assert result["description_generator"]["llm_edge"]["temperature"] == 0.25
+    assert result["description_generator"]["llm_description"]["type"] == "azure"
+    assert result["description_generator"]["llm_refinement"]["name"] == "new-model"
+    assert result["event_generator"]["event_graph"]["llm"]["name"] == "new-model"
+    assert result["dialog_manager"]["critique_config"]["llm"]["type"] == "azure"
+    assert result["dialog_manager"]["llm_user"]["temperature"] == 0.25
+    assert result["analysis"]["llm"]["name"] == "new-model"
+
+
+def test_override_config_deep_merges_yaml_and_applies_llm_overrides(tmp_path):
+    """When an override file is loaded, then nested keys are merged and llm shortcuts are applied consistently."""
+    default_config = {
+        "environment": {"task_description": {"llm": {"type": "openai", "name": "base-task"}}},
+        "description_generator": {
+            "llm_policy": {"type": "openai", "name": "base-policy"},
+            "llm_edge": {"type": "openai", "name": "base-edge"},
+            "llm_description": {"type": "openai", "name": "base-desc"},
+            "llm_refinement": {"type": "openai", "name": "base-refine"},
+        },
+        "event_generator": {"event_graph": {"llm": {"type": "openai", "name": "base-event"}}},
+        "dialog_manager": {
+            "critique_config": {"llm": {"type": "openai", "name": "base-critique"}},
+            "llm_user": {"type": "openai", "name": "base-user"},
+            "llm_chat": {"type": "openai", "name": "base-chat"},
+        },
+        "analysis": {"llm": {"type": "openai", "name": "base-analysis"}},
+        "keep_section": {"nested": {"value": 1}},
+    }
+    override_config_data = {
+        "environment": {"task_description": {"content": "kept"}},
+        "keep_section": {"nested": {"value": 2, "new_value": 3}},
+        "llm_intellagent": {"type": "azure", "name": "override-all", "temperature": 0.1},
+        "llm_chat": {"type": "anthropic", "name": "chat-override"},
+    }
+    default_path = tmp_path / "default.yml"
+    override_path = tmp_path / "override.yml"
+    default_path.write_text(yaml.safe_dump(default_config))
+    override_path.write_text(yaml.safe_dump(override_config_data))
+
+    result = override_config(str(override_path), config_file=str(default_path))
+
+    assert result["environment"]["task_description"]["content"] == "kept"
+    assert result["keep_section"]["nested"] == {"value": 2, "new_value": 3}
+    assert result["environment"]["task_description"]["llm"]["type"] == "azure"
+    assert result["description_generator"]["llm_policy"]["name"] == "override-all"
+    assert result["event_generator"]["event_graph"]["llm"]["type"] == "azure"
+    assert result["dialog_manager"]["llm_chat"]["name"] == "chat-override"
+
+
+def test_get_last_created_directory_returns_newest_directory(tmp_path):
+    """When multiple directories exist, then the newest created directory is returned."""
+    older_dir = tmp_path / "older"
+    newer_dir = tmp_path / "newer"
+    older_dir.mkdir()
+    newer_dir.mkdir()
+
+    result = get_last_created_directory(tmp_path)
+
+    assert result == newer_dir
+
+
+def test_get_last_created_directory_returns_none_for_missing_path(tmp_path):
+    """When the base path does not exist, then the helper should return None without raising."""
+    missing_path = tmp_path / "missing"
+
+    result = get_last_created_directory(missing_path)
+
+    assert result is None
+
+
+def test_get_last_db_returns_latest_memory_db_path(tmp_path):
+    """When a results tree has multiple experiments, then the latest memory database path is returned."""
+    results_dir = tmp_path / "results"
+    older_exp = results_dir / "older" / "experiments" / "run-a"
+    newer_exp = results_dir / "newer" / "experiments" / "run-b"
+    older_exp.mkdir(parents=True)
+    newer_exp.mkdir(parents=True)
+    (older_exp / "memory.db").write_text("old")
+    (newer_exp / "memory.db").write_text("new")
+
+    result = get_last_db(str(results_dir))
+
+    assert result == str(newer_exp / "memory.db")
+
+
+def test_get_last_db_returns_none_when_memory_db_is_missing(tmp_path):
+    """When the newest experiment has no database file, then the helper returns None instead of failing."""
+    results_dir = tmp_path / "results"
+    exp_dir = results_dir / "only" / "experiments" / "run-a"
+    exp_dir.mkdir(parents=True)
+
+    result = get_last_db(str(results_dir))
+
+    assert result is None
+
+
+def test_get_latest_dataset_returns_dataset_path_without_extension(tmp_path):
+    """When datasets exist, then the helper returns the newest dataset path without its file extension."""
+    results_dir = tmp_path / "results"
+    datasets_dir = results_dir / "latest" / "datasets"
+    datasets_dir.mkdir(parents=True)
+    first_dataset = datasets_dir / "dataset_a.pickle"
+    second_dataset = datasets_dir / "dataset_b.pickle"
+    first_dataset.write_text("old")
+    second_dataset.write_text("new")
+    os.utime(first_dataset, (1, 1))
+    os.utime(second_dataset, (2, 2))
+
+    result = get_latest_dataset(str(results_dir))
+
+    assert result == str(datasets_dir / "dataset_b")
+
+
+def test_get_latest_dataset_returns_none_when_no_dataset_exists(tmp_path):
+    """When the dataset folder is absent or empty, then the helper returns None safely."""
+    results_dir = tmp_path / "results"
+    (results_dir / "latest").mkdir(parents=True)
+
+    result = get_latest_dataset(str(results_dir))
+
+    assert result is None


### PR DESCRIPTION
This pull request adds comprehensive docstrings to tests across several files and introduces a new test suite for the file_reading utilities. The docstrings clarify the intent and expected behavior of each test, improving maintainability and readability. 

It adds a new tests/utils/unit/ area with coverage for file discovery, validator collection, config override behavior, and latest artifact lookup helpers. 

To verify run: `uv run pytest`

PR is part of issue: #90 in efforts to enhance coverage.

@Eladlev let me know if you feel there should be additional cases that may have been missed. 